### PR TITLE
Invalidate swagger.yml cache during deployment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,4 +4,4 @@ help:
 deploy:
 	aws s3 sync . s3://$(FLIIT_DEV_WEBSITE_BUCKET) --exclude ".git/" --exclude "README.md" --exclude "Makefile" && \
 	aws configure set preview.cloudfront true && \
-	aws cloudfront create-invalidation --distribution-id $(FLIIT_DEV_SITE_CLOUDFRONT_DIST_ID) --paths /index.html
+	aws cloudfront create-invalidation --distribution-id $(FLIIT_DEV_SITE_CLOUDFRONT_DIST_ID) --paths /index.html /swagger.yml


### PR DESCRIPTION
At the moment we only invalidate the cache of the index.html file (in cloudfront). As it reads the swagger.yml on the fly, we end up seeing the old version after the deployment (for the time the cache lasts).

With this new Makefile I was able to see the changes right after the deployment.